### PR TITLE
Update safety_tesla.h for iBooster use

### DIFF
--- a/panda/board/safety/safety_tesla.h
+++ b/panda/board/safety/safety_tesla.h
@@ -262,6 +262,11 @@ static int tesla_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       to_fwd->RDLR = to_fwd->RDLR + (checksum << 16);
       return 2;
     }
+	  
+    // remove EPB_epasControl
+    if (addr == 0x214) {
+      return false;
+    }
 
     return 2; // Custom EPAS bus
   }


### PR DESCRIPTION
This adds in the 214 removal (Bobby) needs for OP use with iBooster